### PR TITLE
Add client sync event to api

### DIFF
--- a/src/main/java/ftgumod/api/event/FTGUClientSyncEvent.java
+++ b/src/main/java/ftgumod/api/event/FTGUClientSyncEvent.java
@@ -1,0 +1,20 @@
+package ftgumod.api.event;
+
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+public class FTGUClientSyncEvent
+    extends Event {
+
+  /**
+   * This event is fired on the client after FTGU syncs a player's technology
+   * update.
+   */
+  public static class Post
+      extends FTGUClientSyncEvent {
+    //
+  }
+
+  private FTGUClientSyncEvent() {
+    //
+  }
+}

--- a/src/main/java/ftgumod/packet/MessageHandler.java
+++ b/src/main/java/ftgumod/packet/MessageHandler.java
@@ -1,17 +1,66 @@
 package ftgumod.packet;
 
 import ftgumod.FTGU;
+import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.util.IThreadListener;
+import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
+import net.minecraftforge.fml.relauncher.Side;
 
-public abstract class MessageHandler<T extends IMessage> implements IMessageHandler<T, IMessage> {
+public abstract class MessageHandler<T extends IMessage>
+    implements IMessageHandler<T, IMessage> {
 
-	public abstract IMessage handleMessage(EntityPlayer player, T message);
+  public abstract IMessage handleMessage(EntityPlayer player, T message);
 
-	@Override
-	public IMessage onMessage(T message, MessageContext ctx) {
-		return handleMessage(FTGU.PROXY.getPlayerEntity(ctx), message);
-	}
+  @Override
+  public IMessage onMessage(T message, MessageContext ctx) {
+
+    final IThreadListener target = ctx.side == Side.CLIENT ? Minecraft.getMinecraft() : FMLCommonHandler.instance()
+        .getMinecraftServerInstance();
+
+    if (target != null) {
+      target.addScheduledTask(new Runner(message, this, ctx));
+    }
+
+    return null;
+  }
+
+  private final class Runner
+      implements Runnable {
+
+    private final T message;
+    private final MessageContext ctx;
+    private final MessageHandler<T> handler;
+
+    public Runner(final T message, MessageHandler<T> handler, final MessageContext ctx) {
+
+      this.message = message;
+      this.handler = handler;
+      this.ctx = ctx;
+    }
+
+    @Override
+    public void run() {
+
+      final IMessage reply = this.handler.handleMessage(FTGU.PROXY.getPlayerEntity(this.ctx), this.message);
+
+      if (reply != null) {
+
+        if (this.ctx.side == Side.CLIENT) {
+          PacketDispatcher.sendToServer(reply);
+
+        } else {
+          final EntityPlayerMP player = this.ctx.getServerHandler().player;
+
+          if (player != null) {
+            PacketDispatcher.sendTo(reply, player);
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/main/java/ftgumod/packet/client/TechnologyMessage.java
+++ b/src/main/java/ftgumod/packet/client/TechnologyMessage.java
@@ -1,6 +1,7 @@
 package ftgumod.packet.client;
 
 import ftgumod.FTGU;
+import ftgumod.api.event.FTGUClientSyncEvent;
 import ftgumod.api.technology.ITechnology;
 import ftgumod.packet.MessageHandler;
 import ftgumod.packet.server.RequestMessage;
@@ -10,6 +11,7 @@ import ftgumod.technology.TechnologyManager;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 
@@ -107,7 +109,7 @@ public class TechnologyMessage implements IMessage {
 					FTGU.PROXY.displayToastTechnology(toast);
 
 				FTGU.INSTANCE.runCompat("jei");
-				}
+				MinecraftForge.EVENT_BUS.post(new FTGUClientSyncEvent.Post());
 			}
 
 			return null;

--- a/src/main/java/ftgumod/packet/client/TechnologyMessage.java
+++ b/src/main/java/ftgumod/packet/client/TechnologyMessage.java
@@ -13,6 +13,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.ConcurrentModificationException;
 import java.util.HashSet;
@@ -73,41 +74,40 @@ public class TechnologyMessage implements IMessage {
 			if (player == null)
 				return null;
 
-			try {
-				CapabilityTechnology.ITechnology cap = player.getCapability(CapabilityTechnology.TECH_CAP, null);
-				if (cap != null) {
-					if (!message.force && cap.getResearched().size() == message.tech.size())
-						return null;
+			CapabilityTechnology.ITechnology cap = player.getCapability(CapabilityTechnology.TECH_CAP, null);
+			if (cap != null) {
+				if (!message.force && cap.getResearched().size() == message.tech.size())
+					return null;
 
-					for (String name : cap.getResearched())
-						if (!message.tech.contains(name)) {
-							cap.removeResearched(name);
+				// Defensive copy to prevent concurrent modification exception
+				Collection<String> researched = new ArrayList<>(cap.getResearched());
+				for (String name : researched)
+					if (!message.tech.contains(name)) {
+						cap.removeResearched(name);
 
-							String[] split = name.split("#");
-							if (split.length == 2) {
-								Technology tech = TechnologyManager.INSTANCE.getTechnology(new ResourceLocation(split[0]));
-								TechnologyManager.INSTANCE.getProgress(player, tech).revokeCriterion(split[1]);
-							}
+						String[] split = name.split("#");
+						if (split.length == 2) {
+							Technology tech = TechnologyManager.INSTANCE.getTechnology(new ResourceLocation(split[0]));
+							TechnologyManager.INSTANCE.getProgress(player, tech).revokeCriterion(split[1]);
 						}
+					}
 
-					for (String name : message.tech)
-						if (!cap.isResearched(name)) {
-							cap.setResearched(name);
+				for (String name : message.tech)
+					if (!cap.isResearched(name)) {
+						cap.setResearched(name);
 
-							String[] split = name.split("#");
-							if (split.length == 2) {
-								Technology tech = TechnologyManager.INSTANCE.getTechnology(new ResourceLocation(split[0]));
-								TechnologyManager.INSTANCE.getProgress(player, tech).grantCriterion(split[1]);
-							}
+						String[] split = name.split("#");
+						if (split.length == 2) {
+							Technology tech = TechnologyManager.INSTANCE.getTechnology(new ResourceLocation(split[0]));
+							TechnologyManager.INSTANCE.getProgress(player, tech).grantCriterion(split[1]);
 						}
+					}
 
-					for (ITechnology toast : message.toasts)
-						FTGU.PROXY.displayToastTechnology(toast);
+				for (ITechnology toast : message.toasts)
+					FTGU.PROXY.displayToastTechnology(toast);
 
-					FTGU.INSTANCE.runCompat("jei");
+				FTGU.INSTANCE.runCompat("jei");
 				}
-			} catch (ConcurrentModificationException ignore) {
-				return new RequestMessage(); // A different thread changed the researched technologies, data might be lost
 			}
 
 			return null;


### PR DESCRIPTION
1. 61296bc Adds client sync event that fires on the client immediately after FTGU syncs its technology data to the client. This is necessary to allow Artisan Worktables to update its JEI recipe visibility based on FTGU research.
2. 203b9aa Fixes a concurrent modification exception in `TechnologyMessage` by creating a defensive copy to prevent removal from a collection while iterating the collection. This is necessary to also fire the sync event when technologies are removed from a player, ie. by the command. Also unwraps a try / catch block that is no longer necessary.
3. 1eb203d Adds threading to the `MessageHandler` to ensure message handling code is not run on the network thread and is instead run on the appropriate side's main thread. Message handlers should not run their code on the network thread. This was discovered when, in response to the new event, JEI's update was called from the network thread.